### PR TITLE
Add ete3 parsing mode option

### DIFF
--- a/bin/phastSim
+++ b/bin/phastSim
@@ -83,9 +83,10 @@ if sim_run.args.indels:
 # Loads a tree structure from a newick string in ETE3. The returned variable t is the root node for the tree.
 start = time.time()
 if args.mutationsTSVinput !=None:
-	t = Tree(args.treeFile,format=1)
-else:
-	t = Tree(args.treeFile)
+	if args.eteFormat != 1:
+		print("WARNING: ete3 parsing format %s is inappropriate for use with mutationsTSVinput. Setting to parsing mode 1" % args.eteFormat)
+		args.eteFormat = 1
+t = Tree(args.treeFile,format=args.eteFormat)
 time1 = time.time() - start
 print("Time for reading tree with ETE3: " + str(time1))
 	

--- a/phastSim/phastSim.py
+++ b/phastSim/phastSim.py
@@ -168,6 +168,9 @@ def setup_argument_parser():
                         help='Name of (optional) file containing mutation events that are enforced on the tree.'
                         'Sites mutated this way become unmutable through the standard simulated mutation process.', 
                         default=None)
+    parser.add_argument('--eteFormat',
+                        help='Set an ete3 parsing mode with which to read the input tree newick.',
+                        type=int,default=0)
     return parser
 
 


### PR DESCRIPTION
Here's a quick implementation of my requested feature. It retains the current behavior of using mode 0 when unset and forcing mode 1 when mutationsTSVinput is used, with an additional warning message for when it changes the parsing mode. Feel free to remove the warning or make any other edits.