### PR TITLE
Fix genome tree bug

### DIFF
--- a/bin/phastSim
+++ b/bin/phastSim
@@ -142,8 +142,7 @@ if hierarchy:
         infoFile=infoFile,
         verbose=sim_run.args.verbose,
         noNorm=sim_run.args.noNormalization,
-        mutationsTSVinput=sim_run.args.mutationsTSVinput,
-        args = args)
+        mutationsTSVinput=sim_run.args.mutationsTSVinput)
 
     time2 = time.time() - start
     print("Total time after initializing: " + str(time2))
@@ -256,7 +255,13 @@ if args.createMAT:
         print("Protocol buffer output only supported in hierarchical mode, remove --noHierarchy.")
 
     else:
-        
+        if not args.chromosomeName:
+            from Bio import SeqIO
+            chromosome = SeqIO.read(args.reference, format='fasta').id
+
+        else:
+            chromosome = args.chromosomeName
+
         genome_tree.write_genome_mat(
             tree=t, 
             output_path=args.outpath, 

--- a/bin/phastSim
+++ b/bin/phastSim
@@ -142,7 +142,8 @@ if hierarchy:
         infoFile=infoFile,
         verbose=sim_run.args.verbose,
         noNorm=sim_run.args.noNormalization,
-        mutationsTSVinput=sim_run.args.mutationsTSVinput)
+        mutationsTSVinput=sim_run.args.mutationsTSVinput,
+        args = args)
 
     time2 = time.time() - start
     print("Total time after initializing: " + str(time2))

--- a/phastSim/phastSim.py
+++ b/phastSim/phastSim.py
@@ -754,9 +754,8 @@ class phastSimRun:
 
 class GenomeTree_hierarchical:
     def __init__(self, nCodons, codon, ref, gammaRates, omegas, mutMatrix, hyperCategories, hyperMutRates,
-                indels, insertionRate, insertionLength, insertionFrequencies, deletionRate, deletionLength, scale, infoFile, verbose, noNorm, mutationsTSVinput, args):
+                indels, insertionRate, insertionLength, insertionFrequencies, deletionRate, deletionLength, scale, infoFile, verbose, noNorm, mutationsTSVinput):
 
-        self.args = args
         self.codon = codon
         self.ref = ref
         self.refList = list(ref)

--- a/phastSim/phastSim.py
+++ b/phastSim/phastSim.py
@@ -2004,10 +2004,6 @@ class GenomeTree_hierarchical:
         mat = protobuf.data()
         mat.newick = tree.write(format=1)
 
-        if not chromosome:
-            from Bio import SeqIO
-            chromosome = SeqIO.read(self.args.reference, format='fasta').id
-
         self.writeGenomeMAT(tree, mat, chromosome)
 
         f = open(output_path + output_file + ".mat.pb", "wb")

--- a/phastSim/phastSim.py
+++ b/phastSim/phastSim.py
@@ -753,9 +753,10 @@ class phastSimRun:
 
 
 class GenomeTree_hierarchical:
-    def __init__(self, nCodons, codon, ref, gammaRates, omegas, mutMatrix, hyperCategories, hyperMutRates, 
-                indels, insertionRate, insertionLength, insertionFrequencies, deletionRate, deletionLength, scale, infoFile, verbose, noNorm, mutationsTSVinput):
+    def __init__(self, nCodons, codon, ref, gammaRates, omegas, mutMatrix, hyperCategories, hyperMutRates,
+                indels, insertionRate, insertionLength, insertionFrequencies, deletionRate, deletionLength, scale, infoFile, verbose, noNorm, mutationsTSVinput, args):
 
+        self.args = args
         self.codon = codon
         self.ref = ref
         self.refList = list(ref)
@@ -2044,7 +2045,7 @@ class GenomeTree_hierarchical:
                     m_pb.mut_nuc.append(self.alleles[ch])
 
         for c in node.children:
-            self.writeGenomeMAT(c, mat)
+            self.writeGenomeMAT(c, mat, chromosome)
 
 
 


### PR DESCRIPTION
Methods in class `GenomeTree_hierarchical` relied on the property `args` that had not been created (methods such as `write_genome_mat`. This PR adds the args object to this class. 